### PR TITLE
Allow doc generation for new classes in develop branch

### DIFF
--- a/StereoKitDocumenter/DocClass.cs
+++ b/StereoKitDocumenter/DocClass.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace StereoKitDocumenter
 {
@@ -52,9 +53,21 @@ namespace StereoKitDocumenter
 			memberText += string.Join("\n", methodsInstance
 				.Select(methodToString));
 
-			string fieldText = fieldsInstance.Count == 0 ? 
+			// Filter Public fields and properties to display.
+			List<DocField> fieldsInstanceToDisplay = fieldsInstance.FindAll(f => {
+				TypeInfo ti = t.GetTypeInfo();
+				FieldInfo fi = ti.GetDeclaredField(f.name);
+				if (fi != null)
+				{
+					return fi.IsPublic;
+				}
+				PropertyInfo pi = ti.GetDeclaredProperty(f.name);
+				return pi.DeclaringType.IsPublic;
+			});
+
+			string fieldText = fieldsInstanceToDisplay.Count == 0 ?
 				"" : "\n\n## Instance Fields and Properties\n\n|  |  |\n|--|--|\n";
-			fieldText += string.Join("\n", fieldsInstance
+			fieldText += string.Join("\n", fieldsInstanceToDisplay
 				.Select(fieldToString));
 
 			string memberTextStatic = methodsStatic.Count == 0 ?

--- a/StereoKitDocumenter/DocField.cs
+++ b/StereoKitDocumenter/DocField.cs
@@ -31,6 +31,11 @@ namespace StereoKitDocumenter
 			Type result = classType.GetField(name)?.FieldType;
 			if (result == null)
 				result = classType.GetProperty(name)?.PropertyType;
+			// Handle private fields & Properties
+			if (result == null)
+				result = classType.GetTypeInfo().GetDeclaredField(name)?.FieldType;
+			if (result == null)
+				result = classType.GetTypeInfo().GetDeclaredProperty(name)?.PropertyType;
 			return result;
 		}
 		public bool GetStatic(Type classType)

--- a/StereoKitDocumenter/Program.cs
+++ b/StereoKitDocumenter/Program.cs
@@ -179,6 +179,11 @@ namespace StereoKitDocumenter
 		static void ParseMemberSig(string signature, out string nameSpace, out string className, out string member)
 		{
 			nameSpace = GetNamespace(signature);
+			string trimmedSignature = signature.Split('(')[0];
+			if (trimmedSignature.Length > 0)
+			{
+				signature = trimmedSignature;
+			}
 			int last  = signature.LastIndexOf('.');
 			member    = signature[(last+1)..];
 			className = signature[(nameSpace.Length > 0 ? nameSpace.Length + 1 : 0)..last];
@@ -209,6 +214,11 @@ namespace StereoKitDocumenter
 
 		static void ReadField(string signature, XmlReader reader)
 		{
+			// Indexers have P: as type even though they are not fields. We ignore indexers
+			if (signature.Contains("("))
+			{
+				return;
+			}
 			// Get names
 			ParseMemberSig(signature, out string nameSpace, out string className, out string memberName);
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -28,3 +28,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
+
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
Allow doc generation for new classes in develop branch.

1. Ignore generating docs for Indexers, Non Public fields.
2. Better identify overloaded generic methods.
3. Handle . in the arguments for a method signature.
4. Add webrick library which is required for Jekyll server to start successfully.